### PR TITLE
Agregado notificación de uso de cookies

### DIFF
--- a/app/Http/Kernel.php
+++ b/app/Http/Kernel.php
@@ -15,6 +15,7 @@ class Kernel extends HttpKernel
      */
     protected $middleware = [
         \Illuminate\Foundation\Http\Middleware\CheckForMaintenanceMode::class,
+        \Spatie\CookieConsent\CookieConsentMiddleware::class,
     ];
 
     /**

--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,8 @@
     "require": {
         "php": ">=5.6.4",
         "laravel/framework": "5.3.*",
-        "zizaco/entrust": "5.2.x-dev"
+        "zizaco/entrust": "5.2.x-dev",
+        "spatie/laravel-cookie-consent": "^1.6"
     },
     "require-dev": {
         "fzaninotto/faker": "~1.4",

--- a/composer.lock
+++ b/composer.lock
@@ -4,8 +4,8 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "9d074ba1d71147ee40b8f5e44a9fbeb6",
-    "content-hash": "83484111e2241e954ba2b5895282020f",
+    "hash": "b17cf702a0a59c99b7553332a0711feb",
+    "content-hash": "a87824173cf112a009c55b5016ab3b0a",
     "packages": [
         {
             "name": "classpreloader/classpreloader",
@@ -973,6 +973,67 @@
                 "uuid"
             ],
             "time": "2016-08-02 18:39:32"
+        },
+        {
+            "name": "spatie/laravel-cookie-consent",
+            "version": "1.6.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/spatie/laravel-cookie-consent.git",
+                "reference": "a2ed5e851bd9e17139053d71ff0f2317a6fda22e"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/spatie/laravel-cookie-consent/zipball/a2ed5e851bd9e17139053d71ff0f2317a6fda22e",
+                "reference": "a2ed5e851bd9e17139053d71ff0f2317a6fda22e",
+                "shasum": ""
+            },
+            "require": {
+                "illuminate/cookie": "~5.1.0|~5.2.0|~5.3.0",
+                "illuminate/support": "~5.1.0|~5.2.0|~5.3.0",
+                "illuminate/view": "~5.1.0|~5.2.0|~5.3.0",
+                "php": "^5.6|^7.0"
+            },
+            "require-dev": {
+                "fzaninotto/faker": "~1.4",
+                "orchestra/testbench": "3.1",
+                "phpunit/phpunit": "4.*"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Spatie\\CookieConsent\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Freek Van der Herten",
+                    "email": "freek@spatie.be",
+                    "homepage": "https://spatie.be",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Willem Van Bockstal",
+                    "email": "willem@spatie.be",
+                    "homepage": "https://spatie.be",
+                    "role": "Developer"
+                }
+            ],
+            "description": "Make your Laravel app comply with the crazy EU cookie law",
+            "homepage": "https://github.com/spatie/laravel-cookie-consent",
+            "keywords": [
+                "comply",
+                "cookie",
+                "eu",
+                "laravel-cookie-consent",
+                "law",
+                "spatie"
+            ],
+            "time": "2016-10-11 21:46:14"
         },
         {
             "name": "swiftmailer/swiftmailer",

--- a/config/app.php
+++ b/config/app.php
@@ -167,6 +167,8 @@ return [
          * Package Service Providers...
          * 
          */
+
+         Spatie\CookieConsent\CookieConsentServiceProvider::class,
     /*
     |--------------------------------------------------------------------------
     | Entrust Config

--- a/resources/lang/vendor/cookieConsent/de/texts.php
+++ b/resources/lang/vendor/cookieConsent/de/texts.php
@@ -1,0 +1,6 @@
+<?php
+
+return [
+    'message' => 'Diese Seite verwendet Cookies um das Nutzererlebnis zu steigern.',
+    'agree' => 'Akzeptieren',
+];

--- a/resources/lang/vendor/cookieConsent/en/texts.php
+++ b/resources/lang/vendor/cookieConsent/en/texts.php
@@ -1,0 +1,6 @@
+<?php
+
+return [
+    'message' => 'Your experience on this site will be improved by allowing cookies.',
+    'agree' => 'Allow cookies',
+];

--- a/resources/lang/vendor/cookieConsent/es/texts.php
+++ b/resources/lang/vendor/cookieConsent/es/texts.php
@@ -1,0 +1,6 @@
+<?php
+
+return [
+    'message' => 'Su experiencia en este sitio será mejorada con el uso de cookies.',
+    'agree' => 'Aceptar',
+];

--- a/resources/lang/vendor/cookieConsent/fr/texts.php
+++ b/resources/lang/vendor/cookieConsent/fr/texts.php
@@ -1,0 +1,6 @@
+<?php
+
+return [
+    'message' => 'Ce site nécessite l\'autorisation de cookies pour fonctionner correctement.',
+    'agree' => 'Accepter',
+];

--- a/resources/lang/vendor/cookieConsent/pt/texts.php
+++ b/resources/lang/vendor/cookieConsent/pt/texts.php
@@ -1,0 +1,6 @@
+<?php
+
+return [
+    'message' => 'Este site utiliza cookies. Ao navegar no site estará a consentir a sua utilização.',
+    'agree' => 'Aceitar',
+];

--- a/resources/lang/vendor/cookieConsent/sv/texts.php
+++ b/resources/lang/vendor/cookieConsent/sv/texts.php
@@ -1,0 +1,6 @@
+<?php
+
+return [
+    'message' => 'Vi använder kakor (cookies) för att webbplatsen ska fungera på ett bra sätt för dig. Genom att surfa vidare godkänner du att vi använder kakor.',
+    'agree' => 'Jag förstår',
+];

--- a/resources/views/vendor/cookieConsent/dialogContents.blade.php
+++ b/resources/views/vendor/cookieConsent/dialogContents.blade.php
@@ -1,0 +1,11 @@
+<div class="js-cookie-consent cookie-consent">
+
+    <span class="cookie-consent__message">
+        {!! trans('cookieConsent::texts.message') !!}
+    </span>
+
+    <button class="js-cookie-consent-agree cookie-consent__agree">
+        {{ trans('cookieConsent::texts.agree') }}
+    </button>
+
+</div>

--- a/resources/views/vendor/cookieConsent/index.blade.php
+++ b/resources/views/vendor/cookieConsent/index.blade.php
@@ -1,0 +1,41 @@
+@if($cookieConsentConfig['enabled'] && !$alreadyConsentedWithCookies)
+
+    @include('cookieConsent::dialogContents')
+
+    <script>
+
+        window.laravelCookieConsent = (function () {
+
+            function consentWithCookies() {
+                setCookie('{{ $cookieConsentConfig['cookie_name'] }}', 1, 365 * 20);
+                hideCookieDialog();
+            }
+
+            function hideCookieDialog() {
+                var dialogs = document.getElementsByClassName('js-cookie-consent');
+
+                for (var i = 0; i < dialogs.length; ++i) {
+                    dialogs[i].style.display = 'none';
+                }
+            }
+
+            function setCookie(name, value, expirationInDays) {
+                var date = new Date();
+                date.setTime(date.getTime() + (expirationInDays * 24 * 60 * 60 * 1000));
+                document.cookie = name + '=' + value + '; ' + 'expires=' + date.toUTCString() +';path=/';
+            }
+
+            var buttons = document.getElementsByClassName('js-cookie-consent-agree');
+
+            for (var i = 0; i < buttons.length; ++i) {
+                buttons[i].addEventListener('click', consentWithCookies);
+            }
+
+            return {
+                consentWithCookies: consentWithCookies,
+                hideCookieDialog: hideCookieDialog
+            };
+        })();
+    </script>
+
+@endif


### PR DESCRIPTION
Se propone el uso de `spatie/laravel-cookie-consent` para la notificación del uso de cookies en el sitio web.

Ejemplo: 

<img src="https://camo.githubusercontent.com/abb3f7c3b9541e589f01edba76e523a7486861e6/68747470733a2f2f7370617469652e6769746875622e696f2f6c61726176656c2d636f6f6b69652d636f6e73656e742f696d616765732f6469616c6f672e706e67" >

Como tal no posee ningún estilo definido. Recomendaría agregar esto:

``` css
.contcookies {
    position: fixed;
    bottom: 0;
    margin: 0;
    padding: 20px;
    text-align: center;   
    width: 100%;
}
```

Al momento de agregar los estilos al sitio web :smile: :smile:
